### PR TITLE
Android TV support and additional display options

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -29,7 +29,8 @@
 			</intent-filter>
 		</activity>
 	</application>
-	<uses-sdk android:minSdkVersion="17" />
+	<uses-sdk android:minSdkVersion="21" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+	<uses-feature android:name="android.software.leanback" android:required="false" />
 </manifest>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -12,7 +12,7 @@
 			android:defaultValue="http://www.google.com" />
 	</PreferenceCategory>
 	<PreferenceCategory 
-		android:title="Interaction"
+		android:title="Display"
 		android:key="pref_key_interaction_settings">
 		<CheckBoxPreference
 			android:key="pref_key_fullscreen"
@@ -25,6 +25,18 @@
 			android:title="Touchable"
 			android:summaryOff="Interaction will wake the device."
 			android:summaryOn="Interaction will navigate the page."
+			android:defaultValue="false" />
+		<CheckBoxPreference
+			android:key="pref_key_overviewmode"
+			android:title="Overview Mode"
+			android:summaryOff="Overview mode off."
+			android:summaryOn="Overview mode on."
+			android:defaultValue="false" />
+		<CheckBoxPreference
+			android:key="pref_key_wideviewport"
+			android:title="Wide view port"
+			android:summaryOff="Display in normal view port."
+			android:summaryOn="Display in wide view port."
 			android:defaultValue="false" />
 	</PreferenceCategory>
 	<PreferenceCategory 

--- a/src/uk/co/liamnewmarch/daydream/WebsiteDaydream.java
+++ b/src/uk/co/liamnewmarch/daydream/WebsiteDaydream.java
@@ -22,6 +22,8 @@ public class WebsiteDaydream extends DreamService {
 	private String preferenceUrl;
 	private boolean preferenceRefresh;
 	private Integer preferenceInterval;
+	private boolean preferenceOverviewMode;
+	private boolean preferenceWideViewPort;
 
 	@Override
 	public void onAttachedToWindow() {
@@ -36,6 +38,8 @@ public class WebsiteDaydream extends DreamService {
 		preferenceUrl = sharedPreferences.getString("pref_key_url", "http://www.bbc.co.uk/news");
 		preferenceRefresh = sharedPreferences.getBoolean("pref_key_refresh", false);
 		preferenceInterval = Integer.parseInt(sharedPreferences.getString("pref_key_interval", "5"));
+		preferenceOverviewMode = sharedPreferences.getBoolean("pref_key_overviewmode", false);
+		preferenceWideViewPort = sharedPreferences.getBoolean("pref_key_wideviewport", false);
 
 		setFullscreen(preferenceFullscreen);
 		setInteractive(preferenceInteractive);
@@ -55,6 +59,8 @@ public class WebsiteDaydream extends DreamService {
 		webSettings.setJavaScriptEnabled(true);
 		webSettings.setAllowFileAccess(true);
 		webSettings.setPluginState(WebSettings.PluginState.ON_DEMAND);
+		webSettings.setLoadWithOverviewMode(preferenceOverviewMode);
+		webSettings.setUseWideViewPort(preferenceWideViewPort);
 		webSettings.setSavePassword(false);
 		webSettings.setCacheMode(WebSettings.LOAD_DEFAULT);
 		webSettings.setDefaultZoom(WebSettings.ZoomDensity.FAR);


### PR DESCRIPTION
I wanted to use this on Android TV. While the APK installed and ran just fine, there were two issues:

- The manifest did not declare leanback support.
- The web page didn't display in 1080p. That's fixed when overview mode and wide view port are turned on

I did not compile this, but I have it working in a separate project that's targeted at Android 6.0 and I copied over the relevant bits for this project.